### PR TITLE
Yopta 004 добавление уроков

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,22 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
-import { appRoutes } from './routes/routes';
+import { Route, Routes, Navigate } from 'react-router-dom';
+import { appRoutes } from './routes/routes.jsx';
 import MainTemplate from './components/MainTemplate';
-import { NotificationRenderer } from "./components/ui/notification/NotificationRenderer";
+import { NotificationRenderer } from './components/ui/notification/NotificationRenderer';
 
+function renderRoutes(routes) {
+    return routes.map(({ path, element, children, index }) => (
+        <Route key={path || 'index'} path={path} element={element} index={index}>
+            {children && renderRoutes(children)}
+        </Route>
+    ));
+}
 
 export default function App() {
     return (
         <>
             <Routes>
                 <Route path="/" element={<MainTemplate />}>
-                    {appRoutes.map(({ path, element }) => (
-                        <Route key={path} path={path} element={element} />
-                    ))}
+                    {renderRoutes(appRoutes)}
                     <Route path="*" element={<Navigate to="/" replace />} />
                 </Route>
             </Routes>

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -4,5 +4,6 @@ export const API_ENDPOINTS = {
     DICTIONARY: '/dictionary',
     WORDS: '/words',
     TAGS: '/words/tags',
-    ME: '/me'
+    ME: '/me',
+    LESSONS: '/lessons'
 };

--- a/src/api/lessons.js
+++ b/src/api/lessons.js
@@ -1,0 +1,14 @@
+import { apiRequest } from './index.js';
+import { API_ENDPOINTS } from "./endpoints.js";
+
+export function apiGetLessons() {
+    return apiRequest(API_ENDPOINTS.LESSONS, 'GET');
+}
+
+export function apiGetLessonsByCategory(category) {
+    return apiRequest(`${API_ENDPOINTS.LESSONS}/by-category/${encodeURIComponent(category)}`, 'GET');
+}
+
+export function apiGetLesson(slug) {
+    return apiRequest(`${API_ENDPOINTS.LESSONS}/${encodeURIComponent(slug)}`, 'GET');
+}

--- a/src/components/LessonsLayout.tsx
+++ b/src/components/LessonsLayout.tsx
@@ -1,0 +1,23 @@
+import { Outlet, useParams, Link } from 'react-router-dom';
+import styles from './lessonsLayout.module.scss';
+import Breadcrumbs from "./ui/breadcrumbs/breadcrumbs";
+
+export default function LessonsLayout() {
+    const { category, slug } = useParams();
+    const crumbs = [{ label: 'Уроки', to: '/lessons' }];
+
+    if (category) {
+        crumbs.push({ label: decodeURIComponent(category), to: `/lessons/${category}` });
+    }
+
+    if (slug) {
+        crumbs.push({ label: decodeURIComponent(slug.replace(/-/g, ' ')), to: '' });
+    }
+
+    return (
+        <div className="container">
+            <Breadcrumbs/>
+            <Outlet />
+        </div>
+    );
+}

--- a/src/components/MainTemplate.tsx
+++ b/src/components/MainTemplate.tsx
@@ -10,7 +10,8 @@ import Icon from "./ui/icons/Icon";
 const NAV_ITEMS: NavItem[] = [
     { label: 'Словарь', to: ROUTES.DICTIONARY },
     { label: 'Переводчик', to: ROUTES.TRANSLATOR },
-    { label: 'О проекте', to: ROUTES.ABOUT }
+    { label: 'Уроки', to: ROUTES.LESSONS },
+    { label: 'О проекте', to: ROUTES.ABOUT },
 ];
 
 export default function MainTemplate() {

--- a/src/components/lessons/CategoryCard.module.scss
+++ b/src/components/lessons/CategoryCard.module.scss
@@ -1,0 +1,23 @@
+.card {
+  background-color: var(--color-background);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacer-lg);
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+  box-shadow: 4px 4px 0 var(--color-border);
+  user-select: none;
+  text-align: center;
+
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: 6px 6px 0 var(--color-hover);
+    background-color: var(--color-hover);
+  }
+}
+
+.title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-heading);
+}

--- a/src/components/lessons/CategoryCard.tsx
+++ b/src/components/lessons/CategoryCard.tsx
@@ -1,0 +1,19 @@
+import styles from './categoryCard.module.scss';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+    title: string;
+    onClickAction: () => void;
+}
+
+export default function CategoryCard({ title, onClickAction }: Props) {
+    const navigate = useNavigate();
+
+
+    return (
+            <div className={styles.card} onClick={onClickAction}>
+            <div className={styles.title}>{title}</div>
+        </div>
+    );
+}
+

--- a/src/components/ui/breadcrumbs/breadcrumbs.module.scss
+++ b/src/components/ui/breadcrumbs/breadcrumbs.module.scss
@@ -1,0 +1,22 @@
+.breadcrumbs {
+  margin-bottom: var(--spacer-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
+
+  a {
+    color: var(--color-primary);
+    text-decoration: none;
+    margin-right: var(--spacer-xs);
+
+    &:hover {
+      text-decoration: underline;
+      color: var(--color-heading);
+    }
+  }
+
+  span {
+    margin-right: var(--spacer-xs);
+    color: var(--color-text);
+    font-weight: var(--font-weight-medium);
+  }
+}

--- a/src/components/ui/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/ui/breadcrumbs/breadcrumbs.tsx
@@ -1,0 +1,33 @@
+import { Link, useLocation } from 'react-router-dom';
+import styles from './breadcrumbs.module.scss';
+
+interface BreadcrumbsProps {
+    breadcrumbsMap?: Record<string, string>;
+}
+
+export default function Breadcrumbs({ breadcrumbsMap = {} }: BreadcrumbsProps) {
+    const location = useLocation();
+    const pathnames = location.pathname.split('/').filter(Boolean);
+
+    if (pathnames.length === 0) return null;
+
+    const buildName = (segment: string) => {
+        return breadcrumbsMap[segment] || decodeURIComponent(segment);
+    };
+
+    return (
+        <nav className={styles.breadcrumbs}>
+            <Link to="/">Главная</Link>
+            {pathnames.map((segment, index) => {
+                const fullPath = '/' + pathnames.slice(0, index + 1).join('/');
+                const isLast = index === pathnames.length - 1;
+
+                return isLast ? (
+                    <span key={fullPath}> / {buildName(segment)}</span>
+                ) : (
+                    <Link key={fullPath} to={fullPath}> / {buildName(segment)}</Link>
+                );
+            })}
+        </nav>
+    );
+}

--- a/src/constants/languages.js
+++ b/src/constants/languages.js
@@ -8,3 +8,4 @@ export const LANGUAGES_LIST = [
         value: 'eng-ru',
     },
 ]
+

--- a/src/constants/lessonCategories.js
+++ b/src/constants/lessonCategories.js
@@ -1,31 +1,31 @@
 export const LESSON_CATEGORIES = [
     {
-        slug: 'tenses',
+        slug: 'Tenses',
         title: 'Времена',
         icon: '⏳',
     },
     {
-        slug: 'grammar',
+        slug: 'Grammar',
         title: 'Грамматика',
         icon: '📘',
     },
     {
-        slug: 'vocabulary',
+        slug: 'Vocabulary',
         title: 'Лексика',
         icon: '🧠',
     },
     {
-        slug: 'speaking',
+        slug: 'Speaking',
         title: 'Разговорная речь',
         icon: '🗣️',
     },
     {
-        slug: 'writing',
+        slug: 'Writing',
         title: 'Письмо',
         icon: '✍️',
     },
     {
-        slug: 'phrasal-verbs',
+        slug: 'Phrasal-verbs',
         title: 'Фразовые глаголы',
         icon: '🔗',
     }

--- a/src/constants/lessonCategories.js
+++ b/src/constants/lessonCategories.js
@@ -1,0 +1,32 @@
+export const LESSON_CATEGORIES = [
+    {
+        slug: 'tenses',
+        title: 'Времена',
+        icon: '⏳',
+    },
+    {
+        slug: 'grammar',
+        title: 'Грамматика',
+        icon: '📘',
+    },
+    {
+        slug: 'vocabulary',
+        title: 'Лексика',
+        icon: '🧠',
+    },
+    {
+        slug: 'speaking',
+        title: 'Разговорная речь',
+        icon: '🗣️',
+    },
+    {
+        slug: 'writing',
+        title: 'Письмо',
+        icon: '✍️',
+    },
+    {
+        slug: 'phrasal-verbs',
+        title: 'Фразовые глаголы',
+        icon: '🔗',
+    }
+];

--- a/src/hooks/useLessons.ts
+++ b/src/hooks/useLessons.ts
@@ -1,9 +1,11 @@
 import { useState, useCallback } from 'react';
 import { apiGetLessonsByCategory, apiGetLesson } from '../api/lessons';
+import { Lesson } from "../types/lessons";
+import { UseLessonsHook } from "../types/hooks/useLessons";
 
-export default function useLessons() {
-    const [lessonsByCategory, setLessonsByCategory] = useState<object[]>([]);
-    const [lesson, setLesson] = useState<object>([]);
+export default function useLessons():UseLessonsHook {
+    const [lessonsByCategory, setLessonsByCategory] = useState<Lesson[]>([]);
+    const [lesson, setLesson] = useState<Lesson | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 

--- a/src/hooks/useLessons.ts
+++ b/src/hooks/useLessons.ts
@@ -1,0 +1,53 @@
+import { useState, useCallback } from 'react';
+import { apiGetLessonsByCategory, apiGetLesson } from '../api/lessons';
+
+export default function useLessons() {
+    const [lessonsByCategory, setLessonsByCategory] = useState<object[]>([]);
+    const [lesson, setLesson] = useState<object>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchLessonsByCategory = useCallback(async (category) => {
+        setLoading(true);
+        setError(null);
+
+        try {
+            const data = await apiGetLessonsByCategory(category);
+            setLessonsByCategory(data);
+        } catch (err) {
+            if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('Неизвестная ошибка при загрузке слов');
+            }
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    const fetchLesson = useCallback(async (slug) => {
+        setLoading(true);
+        setError(null);
+
+        try {
+            const data = await apiGetLesson(slug);
+            setLesson(data);
+        } catch (err) {
+            if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('Неизвестная ошибка при загрузке слов');
+            }
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+    return {
+        lessonsByCategory,
+        lesson,
+        loading: loading,
+        error: error,
+        fetchLessonsByCategory,
+        fetchLesson,
+    };
+}

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,9 +1,0 @@
-import { Link } from 'react-router-dom';
-
-export default function Home() {
-    return (
-        <div>
-
-        </div>
-    );
-}

--- a/src/pages/lessons/LessonCategory.module.scss
+++ b/src/pages/lessons/LessonCategory.module.scss
@@ -1,0 +1,5 @@
+.contentGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  gap: var(--spacer-md);
+}

--- a/src/pages/lessons/LessonCategory.tsx
+++ b/src/pages/lessons/LessonCategory.tsx
@@ -2,6 +2,8 @@ import { useParams } from "react-router-dom";
 import { useEffect} from "react";
 import useLessons from '../../hooks/useLessons';
 import { useNavigate } from 'react-router-dom';
+import CategoryCard from '../../components/lessons/CategoryCard';
+import styles from './LessonCategory.module.scss';
 
 export default function LessonCategory() {
     const navigate = useNavigate();
@@ -9,8 +11,8 @@ export default function LessonCategory() {
     const { loading, error, lessonsByCategory, fetchLessonsByCategory } = useLessons();
 
     useEffect(() => {
-       void fetchLessonsByCategory(category);
-    }, [])
+       void fetchLessonsByCategory(category!);
+    }, [category])
 
     const openLesson = (slug) => {
         navigate(`/lessons/${category}/${slug}`);
@@ -21,10 +23,15 @@ export default function LessonCategory() {
                 <div className="title title--h2 mb-md">
                     {category}
                 </div>
-                { lessonsByCategory && (
-                    lessonsByCategory.map((lesson) => {
-                       return <div onClick={()=>openLesson(lesson.slug)}>{lesson.title}</div>
-                    })
-                )}
+                <div className={styles.contentGrid}>
+                    { lessonsByCategory && (
+                        lessonsByCategory.map((lesson) => {
+                            return <CategoryCard
+                                key={lesson.id}
+                                title={lesson.title}
+                                onClickAction={()=>openLesson(lesson.slug)}/>
+                        })
+                    )}
+                </div>
             </div>
 }

--- a/src/pages/lessons/LessonCategory.tsx
+++ b/src/pages/lessons/LessonCategory.tsx
@@ -1,0 +1,30 @@
+import { useParams } from "react-router-dom";
+import { useEffect} from "react";
+import useLessons from '../../hooks/useLessons';
+import { useNavigate } from 'react-router-dom';
+
+export default function LessonCategory() {
+    const navigate = useNavigate();
+    const { category } = useParams();
+    const { loading, error, lessonsByCategory, fetchLessonsByCategory } = useLessons();
+
+    useEffect(() => {
+       void fetchLessonsByCategory(category);
+    }, [])
+
+    const openLesson = (slug) => {
+        navigate(`/lessons/${category}/${slug}`);
+    };
+
+
+    return <div className='container'>
+                <div className="title title--h2 mb-md">
+                    {category}
+                </div>
+                { lessonsByCategory && (
+                    lessonsByCategory.map((lesson) => {
+                       return <div onClick={()=>openLesson(lesson.slug)}>{lesson.title}</div>
+                    })
+                )}
+            </div>
+}

--- a/src/pages/lessons/LessonCategory.tsx
+++ b/src/pages/lessons/LessonCategory.tsx
@@ -24,13 +24,18 @@ export default function LessonCategory() {
                     {category}
                 </div>
                 <div className={styles.contentGrid}>
-                    { lessonsByCategory && (
-                        lessonsByCategory.map((lesson) => {
-                            return <CategoryCard
+                    {lessonsByCategory.length > 0 ? (
+                        lessonsByCategory.map((lesson) => (
+                            <CategoryCard
                                 key={lesson.id}
                                 title={lesson.title}
-                                onClickAction={()=>openLesson(lesson.slug)}/>
-                        })
+                                onClickAction={() => openLesson(lesson.slug)}
+                            />
+                        ))
+                    ) : (
+                        <div>
+                            Пока нет уроков по этой теме
+                        </div>
                     )}
                 </div>
             </div>

--- a/src/pages/lessons/LessonPage.module.scss
+++ b/src/pages/lessons/LessonPage.module.scss
@@ -1,0 +1,11 @@
+.example {
+  color: var(--color-primary);
+  font-weight: var(--font-weight-medium);
+  margin-bottom: var(--spacer-sm);
+}
+
+.note {
+  color: var(--color-muted);
+  font-style: italic;
+  margin-bottom: var(--spacer-sm);
+}

--- a/src/pages/lessons/LessonPage.tsx
+++ b/src/pages/lessons/LessonPage.tsx
@@ -1,0 +1,27 @@
+import { useParams } from "react-router-dom";
+import useLessons from "../../hooks/useLessons";
+import { useEffect } from "react";
+
+export default function LessonPage() {
+    const { slug } = useParams();
+    const { loading, error, lesson, fetchLesson } = useLessons();
+
+    useEffect(() => {
+        void fetchLesson(slug);
+    }, [])
+
+    return <div className='container'>
+        <div className="title title--h2 mb-md">
+            {lesson.title}
+        </div>
+        {lesson.content.map(p => {
+            return <p>{p}</p>
+        })}
+        {lesson.examples.map(example => {
+            return <p>{example}</p>
+        })}
+        {lesson.notes.map(note => {
+            return <p>{note}</p>
+        })}
+    </div>
+}

--- a/src/pages/lessons/LessonPage.tsx
+++ b/src/pages/lessons/LessonPage.tsx
@@ -1,27 +1,47 @@
 import { useParams } from "react-router-dom";
 import useLessons from "../../hooks/useLessons";
 import { useEffect } from "react";
+import styles from './LessonPage.module.scss';
 
 export default function LessonPage() {
     const { slug } = useParams();
     const { loading, error, lesson, fetchLesson } = useLessons();
 
     useEffect(() => {
-        void fetchLesson(slug);
-    }, [])
+        void fetchLesson(slug!);
+    }, [slug]);
 
-    return <div className='container'>
-        <div className="title title--h2 mb-md">
-            {lesson.title}
+    if (loading) return <div className="container">Загрузка...</div>;
+    if (error) return <div className="container">Ошибка: {error}</div>;
+    if (!lesson) return null;
+
+    return (
+        <div className="container">
+            <div className="title title--h2 mb-lg">{lesson.title}</div>
+
+            <div className="mb-lg">
+                {lesson.content.map((p, i) => (
+                    <p key={i} className="mb-sm">{p}</p>
+                ))}
+            </div>
+
+            {lesson.examples.length > 0 && (
+                <div className="mb-lg">
+                    <div className="title title--h3 mb-sm">Примеры</div>
+                    {lesson.examples.map((ex, i) => (
+                        <p key={i} className={styles.example}>{ex}</p>
+                    ))}
+                </div>
+            )}
+
+            {lesson.notes.length > 0 && (
+                <div className="mb-lg">
+                    <div className="title title--h3 mb-sm">Заметки</div>
+                    {lesson.notes.map((note, i) => (
+                        <p key={i} className={styles.note}>{note}</p>
+                    ))}
+                </div>
+            )}
         </div>
-        {lesson.content.map(p => {
-            return <p>{p}</p>
-        })}
-        {lesson.examples.map(example => {
-            return <p>{example}</p>
-        })}
-        {lesson.notes.map(note => {
-            return <p>{note}</p>
-        })}
-    </div>
+    );
 }

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -1,10 +1,18 @@
 import { LESSON_CATEGORIES } from '../../constants/lessonCategories';
+import { useNavigate } from 'react-router-dom';
 
 export default function Lessons() {
+
+    const navigate = useNavigate();
+
+    const openCategory = (categorySlug) => {
+        navigate(`/lessons/${categorySlug}`);
+    };
+
     return  <div className='container'>
         <div className="title title--h2 mb-md">Уроки</div>
         {LESSON_CATEGORIES.map((category) => {
-            return  <div key={category.slug}>
+            return  <div key={category.slug} onClick={() => openCategory(category.slug)}>
                 {category.title}
             </div>
         })}

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -1,5 +1,7 @@
 import { LESSON_CATEGORIES } from '../../constants/lessonCategories';
 import { useNavigate } from 'react-router-dom';
+import CategoryCard from "../../components/lessons/CategoryCard";
+import styles from './lessons.module.scss';
 
 export default function Lessons() {
 
@@ -11,10 +13,13 @@ export default function Lessons() {
 
     return  <div className='container'>
         <div className="title title--h2 mb-md">Уроки</div>
-        {LESSON_CATEGORIES.map((category) => {
-            return  <div key={category.slug} onClick={() => openCategory(category.slug)}>
-                {category.title}
-            </div>
-        })}
+        <div className={styles.contentGrid}>
+            {LESSON_CATEGORIES.map((category) => {
+                return  <CategoryCard
+                    key={category.slug}
+                    title={category.title}
+                    onClickAction={() => openCategory(category.slug)}/>
+            })}
+        </div>
     </div>
 }

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -1,0 +1,12 @@
+import { LESSON_CATEGORIES } from '../../constants/lessonCategories';
+
+export default function Lessons() {
+    return  <div className='container'>
+        <div className="title title--h2 mb-md">Уроки</div>
+        {LESSON_CATEGORIES.map((category) => {
+            return  <div key={category.slug}>
+                {category.title}
+            </div>
+        })}
+    </div>
+}

--- a/src/pages/lessons/lessons.module.scss
+++ b/src/pages/lessons/lessons.module.scss
@@ -1,0 +1,5 @@
+.contentGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--spacer-md);
+}

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -1,7 +1,0 @@
-export default function Quiz() {
-    return (
-        <div>
-            Тут будут Ваши результаты
-        </div>
-    );
-}

--- a/src/pages/translator/Translator.tsx
+++ b/src/pages/translator/Translator.tsx
@@ -2,7 +2,7 @@ import Button from "../../components/ui/button/Button";
 import TranslatorForm from "../../components/translator/TranslatorForm";
 import styles from './translator.module.scss';
 import useTranslator from '../../hooks/useTranslator';
-import { LANGUAGES_LIST } from '../../helpers/consts';
+import { LANGUAGES_LIST } from '../../constants/languages';
 import { NotificationService } from '../../services/notificationService';
 import { Status } from "../../types/statuses";
 import useDictionary from "../../hooks/useDictionary";

--- a/src/routes/constants.js
+++ b/src/routes/constants.js
@@ -3,5 +3,6 @@ export const ROUTES = {
     DICTIONARY: '/dictionary',
     RESULT: '/result',
     ABOUT: '/about',
-    TRANSLATOR: '/translator'
+    TRANSLATOR: '/translator',
+    LESSONS: '/lessons',
 };

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -3,6 +3,7 @@ import DictionaryPage from '../pages/dictionary/DictionaryPage';
 import Result from '../pages/Result';
 import About from "../pages/about/About.js";
 import Translator from "../pages/translator/Translator";
+import Lessons from '../pages/lessons/Lessons';
 
 import PrivateRoute from '../components/routes/PrivateRoute';
 import PublicRoute from '../components/routes/PublicRoute';
@@ -42,10 +43,10 @@ export const appRoutes = [
         ),
     },
     {
-        path: ROUTES.RESULT,
+        path: ROUTES.LESSONS,
         element: (
             <PrivateRoute>
-                <Result />
+                <Lessons />
             </PrivateRoute>
         ),
     },

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -5,7 +5,7 @@ import Translator from "../pages/translator/Translator";
 import Lessons from '../pages/lessons/Lessons';
 import LessonCategory from "../pages/lessons/LessonCategory.js";
 import LessonPage from "../pages/lessons/LessonPage.js";
-
+import LessonsLayout from '../components/LessonsLayout';
 import PrivateRoute from '../components/routes/PrivateRoute';
 import PublicRoute from '../components/routes/PublicRoute';
 import { ROUTES } from './constants';
@@ -47,24 +47,22 @@ export const appRoutes = [
         path: ROUTES.LESSONS,
         element: (
             <PrivateRoute>
-                <Lessons />
+                <LessonsLayout />
             </PrivateRoute>
         ),
-    },
-    {
-        path: `${ROUTES.LESSONS}/:category`,
-        element: (
-            <PrivateRoute>
-                <LessonCategory />
-            </PrivateRoute>
-        ),
-    },
-    {
-        path: `${ROUTES.LESSONS}/:category/:slug`,
-        element: (
-            <PrivateRoute>
-                <LessonPage />
-            </PrivateRoute>
-        ),
-    },
+        children: [
+            {
+                index: true,
+                element: <Lessons />,
+            },
+            {
+                path: ':category',
+                element: <LessonCategory />,
+            },
+            {
+                path: ':category/:slug',
+                element: <LessonPage />,
+            },
+        ]
+    }
 ];

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -3,6 +3,8 @@ import DictionaryPage from '../pages/dictionary/DictionaryPage';
 import About from "../pages/about/About.js";
 import Translator from "../pages/translator/Translator";
 import Lessons from '../pages/lessons/Lessons';
+import LessonCategory from "../pages/lessons/LessonCategory.js";
+import LessonPage from "../pages/lessons/LessonPage.js";
 
 import PrivateRoute from '../components/routes/PrivateRoute';
 import PublicRoute from '../components/routes/PublicRoute';
@@ -46,6 +48,22 @@ export const appRoutes = [
         element: (
             <PrivateRoute>
                 <Lessons />
+            </PrivateRoute>
+        ),
+    },
+    {
+        path: `${ROUTES.LESSONS}/:category`,
+        element: (
+            <PrivateRoute>
+                <LessonCategory />
+            </PrivateRoute>
+        ),
+    },
+    {
+        path: `${ROUTES.LESSONS}/:category/:slug`,
+        element: (
+            <PrivateRoute>
+                <LessonPage />
             </PrivateRoute>
         ),
     },

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -1,6 +1,5 @@
 import Login from '../pages/login/Login';
 import DictionaryPage from '../pages/dictionary/DictionaryPage';
-import Result from '../pages/Result';
 import About from "../pages/about/About.js";
 import Translator from "../pages/translator/Translator";
 import Lessons from '../pages/lessons/Lessons';

--- a/src/types/hooks/useLessons.ts
+++ b/src/types/hooks/useLessons.ts
@@ -1,0 +1,10 @@
+import { Lesson } from '../lessons';
+
+export type UseLessonsHook = {
+    lessonsByCategory: Lesson[];
+    lesson: Lesson | null;
+    loading: boolean;
+    error: string | null;
+    fetchLessonsByCategory: (category: string) => Promise<void>;
+    fetchLesson: (slug: string) => Promise<void>;
+};

--- a/src/types/lessons.ts
+++ b/src/types/lessons.ts
@@ -1,0 +1,11 @@
+export type Lesson = {
+    id: number;
+    title: string;
+    slug: string;
+    category: string;
+    content: string[];
+    examples: string[];
+    keywords: string[];
+    notes: string[];
+    created_at: string;
+};


### PR DESCRIPTION
📌 Что сделано:

Импортированы первые учебные материалы
Реализованы страницы на frontend:
Lessons — список категорий
LessonCategory — список уроков по категории
LessonPage — контент одного урока
Добавлены компоненты:
CategoryCard — карточка категории
Breadcrumbs — универсальные хлебные крошки
Внедрена вложенная маршрутизация с шаблоном LessonsLayout
Написан кастомный хук useLessons для работы с API

📁 Структура маршрутов:
/lessons — список категорий
/lessons/:category — уроки категории
/lessons/:category/:slug — детальный просмотр урока